### PR TITLE
[mason] fix(mcp): convert assume from MCP prompt to MCP tool (DBC-162)

### DIFF
--- a/.herd/mcp/src/herd_mcp/server.py
+++ b/.herd/mcp/src/herd_mcp/server.py
@@ -388,9 +388,8 @@ async def herd_record_decision(
     )
 
 
-# Register prompts
-@mcp.prompt()
-async def assume(agent_name: str) -> str:
-    """Assume a herd agent identity with full context."""
+@mcp.tool()
+async def herd_assume(agent_name: str) -> str:
+    """Assume a herd agent identity with full context. Returns the full identity prompt for the specified agent."""
     registry = get_adapter_registry()
     return await assume_role.execute(agent_name, registry)


### PR DESCRIPTION
## Summary
- Converted `assume` from `@mcp.prompt()` to `@mcp.tool()` decorator
- Renamed function from `assume` to `herd_assume` to match naming convention
- Updated docstring to clarify it returns the full identity prompt

## Why
Claude Code doesn't surface MCP prompts as slash commands, but does surface MCP tools. This makes the assume functionality callable as `herd_assume` from the MCP tool interface.

## Changes
- `.herd/mcp/src/herd_mcp/server.py`: Changed decorator and function name
- No changes needed to `assume_role.py` - it already returns a string which works for both prompts and tools

## Testing
- Server tests pass (`tests/test_server.py`)
- Linting passes (`ruff check`)
- Formatting passes (`black --check`)

Built with Claude Code